### PR TITLE
Implement flexbox in partners section Solves #103

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,6 +22,7 @@
 			padding-bottom: 3%;
     			width: 200px;
 			transition: 0.4s;
+			height: auto;
 		}
 
 		.partners .sponsor:hover {
@@ -209,6 +210,11 @@ table {
 }
 .partners .main-title  {
   	margin-top: 0;
+}
+.container-flex {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-around;
 }
 .btn-top {
   	display: inline-block;

--- a/_includes/top.html
+++ b/_includes/top.html
@@ -8,7 +8,7 @@
     </div>
 </section>
 <section class="partners">
-    <div class="container">
+    <div class="container-flex">
       <div class="col col-1">
        
         <h1>Platinum Sponsor</h1>


### PR DESCRIPTION
### Implement flexbox in partners section, solves issue #103 
Apart from implementing flexbox I also set sponsors `height` to `auto` so it properly displays logos.

Screen preview:
![new_partners_section](https://user-images.githubusercontent.com/16598854/34629267-d83d524a-f267-11e7-84d0-1e324d155307.png)

Link preview: https://kubami9.github.io/2014.fossasia.org-km-contribute/
